### PR TITLE
TEP-2256 Adds Privacy Manifest file and updates Package.swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ Pods
 
 #Carthage
 Carthage/Build
+
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,26 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
     name: "SwiftyJSON",
     products: [
-        .library(name: "SwiftyJSON", targets: ["SwiftyJSON"])
+        .library(
+            name: "SwiftyJSON",
+            targets: ["SwiftyJSON"]
+        )
     ],
     targets: [
-        .target(name: "SwiftyJSON", dependencies: []),
-        .testTarget(name: "SwiftJSONTests", dependencies: ["SwiftyJSON"])
+        .target(
+            name: "SwiftyJSON",
+            dependencies: [],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ]
+        ),
+        .testTarget(
+            name: "SwiftJSONTests",
+            dependencies: ["SwiftyJSON"]
+        )
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Source/SwiftyJSON/PrivacyInfo.xcprivacy
+++ b/Source/SwiftyJSON/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/SwiftyJSON.podspec
+++ b/SwiftyJSON.podspec
@@ -14,4 +14,9 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   s.source   = { :git => "https://github.com/SwiftyJSON/SwiftyJSON.git", :tag => s.version }
   s.source_files = "Source/SwiftyJSON/*.swift"
+  s.resource_bundles = {
+    'SwiftyJSON' => [
+      'Source/SwiftyJSON/PrivacyInfo.xcprivacy'
+    ]
+  }
 end


### PR DESCRIPTION
## Changelog

+ [TEP-2256] Adds Privacy Manifest file and updates Package.swift

Merge Checklist:

 - [n/a] Does this have tests?
 - [n/a] Does this have documentation?
 - [n/a] Does this break the public API (Requires major version bump)?
 - [n/a] Is this a new feature (Requires minor version bump)?

[TEP-2256]: https://jackpocket.atlassian.net/browse/TEP-2256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ